### PR TITLE
Fix: Cell area conservation via metric compensation (closes #11)

### DIFF
--- a/app/simulation/cell_dfc.py
+++ b/app/simulation/cell_dfc.py
@@ -205,8 +205,12 @@ class CellDFC:
         deformation *= self.deformation_amplitude / len(self.deformation_phases)
         perturbed_size = self.radial_size * (1.0 + deformation)
 
+        # Metric compensation: at elevation el, azimuthal distances shrink
+        # by cos(el). Expand the azimuthal component to conserve area.
+        cos_el = max(np.cos(self.center_aer[1]), 0.1)  # Clamp to avoid singularity at poles
+
         # Vectorized AER computation (no Python loop)
-        az = self.center_aer[0] + perturbed_size * np.cos(angles)  # (N,)
+        az = self.center_aer[0] + perturbed_size * np.cos(angles) / cos_el  # (N,)
         el = self.center_aer[1] + perturbed_size * np.sin(angles)  # (N,)
         r = np.full(self.num_vertices, self.center_aer[2])          # (N,)
 


### PR DESCRIPTION
## Summary
- Azimuthal contour component scaled by 1/cos(elevation) to compensate metric contraction
- Cells now correctly elongate toward poles instead of shrinking
- Closes #11

## Test plan
- [ ] `python tests/test_cell.py && python tests/test_simulation.py`

@codex The metric compensation divides by cos(el), clamped to 0.1. But at el=84.3° (cos=0.1), cells would be 10x elongated in azimuth. Is that physically reasonable for a biological cell? What happens to the collision detection when cells are that elongated? 🌍

_@codex 指标补偿除以cos(el)，截断为0.1。但在el=84.3°时，细胞在方位角上会被拉伸10倍。这对生物细胞来说物理上合理吗？_ 🇨🇳

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

**NOTE to @codex: CODE REVIEW ONLY. No execution needed.**