### PR TITLE
Feat: CSV export + YSL ring (closes #16)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, StreamingResponse
 from pydantic import BaseModel
 
 from .simulation.layer_dfc import DFCLayer
@@ -48,6 +48,7 @@ sim_state: dict = {
     "dfc_layer": None,
     "running": False,
     "speed": 50,
+    "metrics_history": [],
 }
 
 # ---------------------------------------------------------------------------
@@ -104,6 +105,7 @@ async def init_sim(config: SimConfig):
     )
     sim_state["speed"] = config.speed_ms
     sim_state["running"] = False
+    sim_state["metrics_history"] = []
 
     return {
         "status": "initialized",
@@ -135,6 +137,10 @@ async def step():
     env.update()
     sim_state["dfc_layer"].update(env.margin_velocity, evl_elevation=env.margin_elevation)
 
+    # Accumulate metrics for CSV export
+    metrics = sim_state["dfc_layer"].compute_cluster_metrics()
+    sim_state["metrics_history"].append(metrics)
+
     return {
         "dfc_layer": sim_state["dfc_layer"].get_state(),
         "environment": env.get_state(),
@@ -151,6 +157,31 @@ async def get_state():
         "dfc_layer": sim_state["dfc_layer"].get_state(),
         "environment": sim_state["env"].get_state(),
     }
+
+
+@app.get("/api/simulation/export-csv")
+async def export_csv():
+    """Export accumulated simulation metrics as CSV download."""
+    import io
+    import csv
+
+    history = sim_state.get("metrics_history", [])
+    if not history:
+        return {"error": "No simulation history. Run the simulation first."}
+
+    output = io.StringIO()
+    keys = list(history[0].keys())
+    writer = csv.DictWriter(output, fieldnames=['step'] + keys)
+    writer.writeheader()
+    for i, row in enumerate(history):
+        writer.writerow({'step': i, **{k: row.get(k, '') for k in keys}})
+
+    output.seek(0)
+    return StreamingResponse(
+        iter([output.getvalue()]),
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=simulation_metrics.csv"}
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -190,6 +221,11 @@ async def ws_sim(websocket: WebSocket):
             if sim_state["running"] and sim_state["dfc_layer"]:
                 sim_state["env"].update()
                 sim_state["dfc_layer"].update(sim_state["env"].margin_velocity, evl_elevation=sim_state["env"].margin_elevation)
+
+                # Accumulate metrics for CSV export
+                metrics = sim_state["dfc_layer"].compute_cluster_metrics()
+                sim_state["metrics_history"].append(metrics)
+
                 state = {
                     "dfc_layer": sim_state["dfc_layer"].get_state(),
                     "environment": sim_state["env"].get_state(),

--- a/app/simulation/layer_dfc.py
+++ b/app/simulation/layer_dfc.py
@@ -375,6 +375,24 @@ class DFCLayer:
             'num_active': len(active),
         }
 
+    def export_metrics_csv(self, filepath: str, history: list):
+        """Export simulation metrics history to CSV.
+
+        Args:
+            filepath: Output CSV file path.
+            history: List of dicts from compute_cluster_metrics() at each step.
+        """
+        import csv
+        if not history:
+            return
+        keys = list(history[0].keys())
+        with open(filepath, 'w', newline='') as f:
+            writer = csv.DictWriter(f, fieldnames=['step'] + keys)
+            writer.writeheader()
+            for i, row in enumerate(history):
+                row_with_step = {'step': i, **row}
+                writer.writerow(row_with_step)
+
     def get_state(self) -> dict:
         """Return a JSON-serializable snapshot of the layer.
 

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -75,6 +75,9 @@
                     <button id="btn-pause" title="Pause the running simulation" disabled>Pause</button>
                     <button id="btn-step" title="Advance the simulation by a single time step">Step</button>
                 </div>
+                <div class="btn-row" style="margin-top: 6px;">
+                    <button id="btn-download-csv" title="Download simulation metrics history as CSV">Download CSV</button>
+                </div>
             </section>
 
             <section class="panel-section">
@@ -167,6 +170,16 @@
     <script src="/static/js/renderer3d.js"></script>
     <script src="/static/js/controls.js"></script>
     <script src="/static/js/app.js"></script>
+
+    <!-- CSV download handler -->
+    <script>
+    (function () {
+        var btnCSV = document.getElementById('btn-download-csv');
+        btnCSV.addEventListener('click', function () {
+            window.location.href = '/api/simulation/export-csv';
+        });
+    })();
+    </script>
 
     <!-- Help modal and section help toggle logic -->
     <script>


### PR DESCRIPTION
## Summary
- CSV export endpoint with StreamingResponse
- Metrics accumulation per step
- Download button in frontend

@codex CSV出力はStreamingResponseで実装した。でもWebSocketモードでは履歴がメモリに無限に蓄積する。循環バッファに切り替えるべき？最大何ステップ保持すべき？🇯🇵

**CODE REVIEW ONLY.**
🤖 Generated with [Claude Code](https://claude.ai/claude-code)