### PR TITLE
Feat: Theory doc, pipeline SVG, and viewport keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ where **d** is the great-circle distance of each cell from the cluster centroid,
 
 The system consists of a FastAPI server that runs the simulation engine and a Three.js frontend that renders the results in real time. Communication happens over REST (for initialization and control) and WebSocket (for continuous state streaming during playback).
 
+## Pipeline
+
+![Pipeline](docs/svg/pipeline.svg)
+
+Per-tick processing flow: (1) initialize cells, (2) update positions with EVL velocity + noise, (3) detect pairwise collisions, (4) resolve overlaps on the tangent plane, (5) convert to Cartesian, (6) serialize state, (7) push to the Three.js renderer over WebSocket.
+
 ---
 
 ## Features
@@ -178,23 +184,25 @@ SCIAN_EVL_SpherSIM/
 │   ├── test_collision.py         # 7 tests: distance, overlap, resolution, symmetry
 │   └── test_simulation.py        # 6 tests: pipeline, serialization, geometry, bounds
 ├── docs/
-│   ├── architecture.md           # System design and API reference
-│   ├── biological_model.md       # Zebrafish biology and simulation model
-│   ├── epiboly_biology.md        # Epiboly process biology
-│   ├── development_history.md    # Changelog from MATLAB v1.x to Python v2.0
-│   ├── references.md             # Academic papers and software libraries
-│   ├── user_guide.md             # Installation, usage, and troubleshooting
+│   ├── architecture.md                  # System design and API reference
+│   ├── spherical_mechanics_theory.md    # Deep theory: metric, Haversine, forces, metrics
+│   ├── biological_model.md              # Zebrafish biology and simulation model
+│   ├── epiboly_biology.md               # Epiboly process biology
+│   ├── development_history.md           # Changelog from MATLAB v1.x to Python v2.x
+│   ├── references.md                    # Academic papers and software libraries
+│   ├── user_guide.md                    # Installation, usage, and troubleshooting
 │   ├── png/
-│   │   └── frontend.png          # Frontend screenshot
+│   │   └── frontend.png                 # Frontend screenshot
 │   └── svg/
-│       ├── architecture.svg      # System architecture diagram
-│       ├── spherical_model.svg   # Spherical embryo model
-│       ├── simulation_flow.svg   # Simulation step pipeline
-│       ├── coordinate_system.svg # AER coordinate system
-│       ├── cartesian_push.svg    # Cartesian push collision diagram
-│       ├── epiboly_stages.svg    # Epiboly progression stages
-│       ├── evl_coupling.svg      # EVL drag coupling diagram
-│       └── app_screenshot.svg    # Application interface mockup
+│       ├── architecture.svg             # System architecture diagram
+│       ├── pipeline.svg                 # Per-tick processing pipeline
+│       ├── simulation_flow.svg          # (legacy) simulation step pipeline
+│       ├── spherical_model.svg          # Spherical embryo model
+│       ├── coordinate_system.svg        # AER coordinate system
+│       ├── cartesian_push.svg           # Cartesian push collision diagram
+│       ├── epiboly_stages.svg           # Epiboly progression stages
+│       ├── evl_coupling.svg             # EVL drag coupling diagram
+│       └── app_screenshot.svg           # Application interface mockup
 ├── legacy/                       # Original MATLAB code and GUIDE files
 ├── build.spec                    # PyInstaller spec file
 ├── Build_PyInstaller.ps1         # PowerShell build script
@@ -235,7 +243,9 @@ SCIAN_EVL_SpherSIM/
 ## Documentation
 
 - [Architecture](docs/architecture.md) -- System design, API endpoints, WebSocket protocol, data flow
+- [Spherical Mechanics Theory](docs/spherical_mechanics_theory.md) -- Deep equations reference: metric, Haversine, Cartesian push, EVL coupling, metrics
 - [Biological Model](docs/biological_model.md) -- Zebrafish biology, DFC migration, collision model
+- [Epiboly Biology](docs/epiboly_biology.md) -- Epiboly process and DFC context
 - [Development History](docs/development_history.md) -- Changelog from MATLAB to Python/Web
 - [References](docs/references.md) -- Academic papers and software libraries
 - [User Guide](docs/user_guide.md) -- Installation, usage, parameters, troubleshooting

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -340,3 +340,70 @@ button:disabled {
 ::-webkit-scrollbar-thumb:hover {
     background: var(--text-secondary);
 }
+
+/* ---- Viewport keyboard hints overlay ---- */
+#viewport { position: relative; }
+
+.viewport-hints {
+    position: absolute;
+    left: 12px;
+    bottom: 12px;
+    background: rgba(13, 21, 32, 0.78);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 8px 10px;
+    font-size: 11px;
+    color: var(--text-secondary);
+    line-height: 1.5;
+    pointer-events: auto;
+    z-index: 10;
+    min-width: 140px;
+    backdrop-filter: blur(3px);
+}
+
+.viewport-hints .hint-row { display: block; white-space: nowrap; }
+.viewport-hints .hint-sep {
+    height: 1px;
+    background: var(--border);
+    margin: 6px 0;
+    opacity: 0.6;
+}
+
+.viewport-hints kbd {
+    display: inline-block;
+    background: #1a2538;
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    padding: 1px 5px;
+    font-family: monospace;
+    font-size: 10px;
+    color: #9fc6f0;
+    margin-right: 4px;
+    min-width: 18px;
+    text-align: center;
+}
+
+.viewport-hints.hints-collapsed .hint-row,
+.viewport-hints.hints-collapsed .hint-sep {
+    display: none;
+}
+
+.viewport-hints.hints-collapsed {
+    min-width: 0;
+    padding: 2px 6px;
+}
+
+.hints-toggle {
+    position: absolute;
+    top: 2px;
+    right: 4px;
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 0 4px;
+    font-size: 14px;
+    line-height: 1;
+}
+
+.hints-toggle:hover { color: var(--accent); }

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -160,6 +160,19 @@
         <!-- Right: 3D viewport -->
         <main id="viewport">
             <canvas id="three-canvas"></canvas>
+            <!-- Keyboard / mouse hints overlay -->
+            <div id="viewport-hints" class="viewport-hints" title="Keyboard and mouse shortcuts">
+                <div class="hint-row"><kbd>Space</kbd> play / pause</div>
+                <div class="hint-row"><kbd>S</kbd> single step</div>
+                <div class="hint-row"><kbd>I</kbd> init / reset</div>
+                <div class="hint-row"><kbd>?</kbd> open help</div>
+                <div class="hint-row"><kbd>Esc</kbd> close help</div>
+                <div class="hint-sep"></div>
+                <div class="hint-row">LMB drag: orbit</div>
+                <div class="hint-row">RMB drag: pan</div>
+                <div class="hint-row">Wheel: zoom</div>
+                <button id="btn-hints-toggle" class="hints-toggle" title="Hide / show hints">-</button>
+            </div>
         </main>
     </div>
 
@@ -224,6 +237,55 @@
                     }
                 }
             });
+        });
+    })();
+    </script>
+
+    <!-- Keyboard shortcuts and viewport hints collapse -->
+    <script>
+    (function () {
+        var hints = document.getElementById('viewport-hints');
+        var btnToggle = document.getElementById('btn-hints-toggle');
+        if (btnToggle && hints) {
+            btnToggle.addEventListener('click', function (e) {
+                e.stopPropagation();
+                hints.classList.toggle('hints-collapsed');
+                btnToggle.textContent = hints.classList.contains('hints-collapsed') ? '+' : '-';
+            });
+        }
+
+        // Keyboard shortcuts. Ignore when user is typing in an input.
+        document.addEventListener('keydown', function (e) {
+            var tag = (e.target && e.target.tagName) || '';
+            if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+            if (e.ctrlKey || e.metaKey || e.altKey) return;
+
+            var modal = document.getElementById('help-modal');
+            var btnInit  = document.getElementById('btn-init');
+            var btnPlay  = document.getElementById('btn-play');
+            var btnPause = document.getElementById('btn-pause');
+            var btnStep  = document.getElementById('btn-step');
+            var btnHelp  = document.getElementById('btn-help');
+
+            switch (e.key) {
+                case ' ':
+                    e.preventDefault();
+                    // Toggle based on which button is enabled
+                    if (btnPause && !btnPause.disabled) { btnPause.click(); }
+                    else if (btnPlay && !btnPlay.disabled) { btnPlay.click(); }
+                    break;
+                case 's':
+                case 'S':
+                    if (btnStep && !btnStep.disabled) btnStep.click();
+                    break;
+                case 'i':
+                case 'I':
+                    if (btnInit && !btnInit.disabled) btnInit.click();
+                    break;
+                case '?':
+                    if (btnHelp) btnHelp.click();
+                    break;
+            }
         });
     })();
     </script>

--- a/docs/spherical_mechanics_theory.md
+++ b/docs/spherical_mechanics_theory.md
@@ -1,0 +1,317 @@
+# Spherical Mechanics Theory
+
+This document is the deep technical reference for the mathematics and physics behind the SCIAN EVL SpherSIM simulator. It is intended as a standalone reference: each section defines the problem, derives the relevant equation, explains each variable, and states its physical or numerical interpretation. For higher-level biology see [biological_model.md](biological_model.md) and [epiboly_biology.md](epiboly_biology.md); for the software architecture see [architecture.md](architecture.md).
+
+---
+
+## 1. Coordinate System (AER)
+
+All cell positions are stored in **AER** (Azimuth, Elevation, Radius) spherical coordinates. For a sphere of radius `R`:
+
+```
+x = R * cos(el) * cos(az)
+y = R * cos(el) * sin(az)
+z = R * sin(el)
+```
+
+| Symbol | Meaning | Range | Unit |
+|---|---|---|---|
+| `az` | Longitude around the vertical (Z) axis | `[-pi, pi]` | rad |
+| `el` | Latitude from the equatorial plane | `[-pi/2, +pi/2]` | rad |
+| `R` | Distance from sphere center | `R_embryo` | spatial units |
+
+**Why AER?** The DFC cluster is a narrow patch on the dorsal side. Azimuth/elevation map naturally to "east-west" and "north-south" displacements that match how experimentalists describe epiboly. Radius is a nuisance coordinate held constant.
+
+**Periodic boundary.** Azimuth wraps: after each integration step we renormalize `az <- ((az + pi) mod 2*pi) - pi` so the seam at the anti-meridian is invisible to the dynamics.
+
+**Clamped boundary.** Elevation is clamped to `[-pi/2 + eps, +pi/2 - eps]`. Cells do not pass through the poles because the azimuthal coordinate becomes singular there.
+
+---
+
+## 2. The Spherical Metric and Why Flat Geometry Fails
+
+On a sphere of radius `R`, the infinitesimal arc length is
+
+```
+ds^2 = R^2 * (d_el^2 + cos^2(el) * d_az^2)
+```
+
+| Symbol | Meaning |
+|---|---|
+| `ds` | Physical arc length on the surface |
+| `d_el`, `d_az` | Small coordinate increments |
+| `cos^2(el)` | Metric coefficient that shrinks azimuthal distances near the poles |
+
+**Interpretation.** An azimuth increment `d_az` covers a physical distance `R * cos(el) * d_az`, which varies with latitude:
+
+| Latitude `el` | `cos(el)` | Physical length of `d_az = 0.1` |
+|---|---|---|
+| 0 (equator) | 1.0 | `0.1 * R` |
+| 60 degrees | 0.5 | `0.05 * R` |
+| 80 degrees | 0.17 | `0.017 * R` |
+| 90 degrees (pole) | 0.0 | 0 (singular) |
+
+**Consequence for collisions.** A naive resolver that pushes two overlapping cells by equal `d_az` increments separates them by **half the physical distance** at 60 degrees latitude compared to the equator. Near the poles, they barely move apart at all. This is the bug that motivated the v2.2 Cartesian tangent-plane push (section 5).
+
+---
+
+## 3. Great-Circle (Haversine) Distance
+
+The true geodesic distance between two points `(az_1, el_1)` and `(az_2, el_2)` on a unit sphere is
+
+```
+d_hav = 2 * arcsin( sqrt( sin^2((el_2 - el_1)/2)
+                        + cos(el_1) * cos(el_2) * sin^2((az_2 - az_1)/2) ) )
+```
+
+| Symbol | Meaning | Unit |
+|---|---|---|
+| `d_hav` | Angular great-circle distance | rad |
+| `el_i, az_i` | Cell centers in AER | rad |
+
+**Physical distance** on a sphere of radius `R` is `R * d_hav`.
+
+**Why not just `sqrt(d_az^2 + d_el^2)`?** The flat-space Pythagoras approximation:
+- Over-estimates distance near the poles (because it ignores the `cos(el)` metric factor).
+- Fails entirely for points on opposite sides of the sphere.
+- Produces direction-dependent errors for cells separated by more than ~0.3 rad.
+
+**Haversine is numerically stable** for small AND large separations because the outer `arcsin` avoids the `arccos(1 - small)` cancellation error that plagues the spherical law of cosines.
+
+**Used in**: collision detection, cluster spread computation, EVL distance for elastic coupling.
+
+---
+
+## 4. EVL Kinematic Boundary
+
+The EVL margin is not simulated as individual cells. It is a **kinematic line of latitude** moving toward the vegetal pole:
+
+```
+el_EVL(t) = el_EVL(0) + v_evl * t
+```
+
+with `v_evl > 0` in the standard convention where elevation decreases vegetalward; the sign flip is handled by the velocity vector `[0, -(pi/2) * evl_speed, 0]` applied to cells.
+
+| Symbol | Meaning | Unit | Typical |
+|---|---|---|---|
+| `el_EVL(t)` | EVL margin latitude at time `t` | rad | starts near +0.8, moves toward 0 |
+| `v_evl` | Angular migration speed of the EVL | rad/step | `0.005` |
+
+**Why kinematic?** The EVL in real embryos is a large epithelial sheet with roughly uniform margin velocity at the time scale of DFC migration. Modelling it as thousands of individual cells would be wasteful for this study, and its bulk advance is the only force the DFCs actually feel from it. The simplification is a common choice in morphogenesis modelling.
+
+---
+
+## 5. Cartesian Tangent-Plane Collision Resolution
+
+**Problem.** Section 2 showed that pushing cells apart in AER space produces latitude-dependent physical separations. The fix is to push in 3D Cartesian space along the local tangent plane.
+
+**Algorithm.** For two overlapping cells `i` and `j` with 3D positions `p_i`, `p_j` on a sphere of radius `R`:
+
+```
+1. n_i     = p_i / R                                # outward normal at cell i
+2. d_vec   = p_i - p_j                              # direction from j to i in 3D
+3. d_tan   = d_vec - (d_vec . n_i) * n_i            # remove radial component
+4. d_hat   = d_tan / ||d_tan||                      # unit tangent direction
+5. p_i'    = p_i + (overlap/2) * d_hat              # push i outward
+6. p_i''   = R * (p_i' / ||p_i'||)                  # re-project onto sphere
+7. (az_i, el_i, R) = cart2sph(p_i'')                # return to AER
+```
+
+Cell `j` is pushed by the opposite direction with symmetric magnitude.
+
+| Symbol | Meaning |
+|---|---|
+| `n_i` | Outward unit normal at cell `i` |
+| `d_tan` | Separation vector projected onto the tangent plane at `i` |
+| `overlap` | `(r_i + r_j) - d_hav` , the amount of penetration |
+| `R` | Embryo radius, preserved by the final re-projection |
+
+**Compact form**
+
+```
+p_i_new = R * normalize( p_i + (overlap/2) * d_tan / ||d_tan|| )
+```
+
+**Properties.**
+- **Latitude-independent.** The push magnitude is measured in real 3D space, not in coordinate space.
+- **Symmetry-preserving.** Equal-and-opposite displacements conserve the midpoint of the pair.
+- **Manifold-preserving.** The final re-projection onto the sphere eliminates the tiny out-of-surface error from the tangential step.
+
+This same projection pattern is used for differential adhesion forces, which suffered from the same metric distortion before v2.2.
+
+---
+
+## 6. EVL Elastic Coupling Force
+
+Experiments (Ablooglu et al., 2021) show DFCs maintain **apical tight-junction attachments** to the EVL, acting as elastic tethers. Pull strength decays with distance from the EVL margin:
+
+```
+F_EVL = k * d * exp( -d / lambda )
+```
+
+| Symbol | Meaning | Unit | Default |
+|---|---|---|---|
+| `F_EVL` | Force magnitude on a DFC | same as `k * rad` | — |
+| `k` | Spring constant | 1/step | tuned per run |
+| `d` | `el_cell - el_EVL`, the elevation separation | rad | — |
+| `lambda` | Attachment decay length | rad | `0.3` |
+
+**Interpretation.**
+- `d = 0` (cell at margin): force = 0 (no tether stretch).
+- `d = lambda`: force = `k * lambda / e` ≈ 37% of peak, the characteristic attachment scale.
+- `d >> lambda`: force → 0 (cells that have fallen behind detach from the EVL).
+- `d < 0` (cell below margin): clipped to zero in the implementation (cells cannot be pushed backward by a downstream EVL).
+
+**Biological consequence.** This generates the observed leader-follower pattern: cells closest to the EVL (small `d`) get pulled hardest and migrate fastest, while cells further from the margin (large `d`) lag — exactly matching live-imaging observations.
+
+---
+
+## 7. Persistent Random Walk
+
+DFCs exhibit filopodial persistence: they commit to a direction for several steps before reorienting. The velocity update is
+
+```
+v = v_EVL + alpha * ( cos(theta_bias), sin(theta_bias) ) + sigma * xi
+```
+
+| Symbol | Meaning |
+|---|---|
+| `v_EVL` | Elastic coupling velocity (section 6) |
+| `alpha` | Persistence amplitude, `0.3 * ||v_EVL||` |
+| `theta_bias` | Current directional bias, held for `tau` steps |
+| `tau` | Persistence time, drawn from `Uniform(8, 25)` |
+| `sigma` | Gaussian noise standard deviation, user parameter |
+| `xi ~ N(0, I_2)` | Uncorrelated 2D Gaussian |
+
+Each time the persistence counter expires, a new `theta_bias` is drawn uniformly in `[0, 2*pi)` and a new `tau` is drawn. This produces trajectories with short-time ballistic motion and long-time diffusive motion — a Langevin-like process on the sphere.
+
+---
+
+## 8. Differential Adhesion
+
+Following Steinberg (1963), cell-cell contact forces are modeled with a smooth attractive potential:
+
+```
+F_adh = s * (d - d_contact) / (d_max - d_contact) * d_hat    for d_contact < d < d_max
+F_adh = 0                                                    otherwise
+```
+
+| Symbol | Meaning |
+|---|---|
+| `s` | Adhesion strength |
+| `d` | Haversine distance between cell centers |
+| `d_contact` | Distance below which collision repulsion takes over |
+| `d_max` | Distance beyond which adhesion vanishes |
+| `d_hat` | Unit vector from cell `i` to cell `j` on the tangent plane |
+
+**Interpretation.** Cells in the interaction band `(d_contact, d_max)` feel a mild pull toward each other that is zero at `d_contact` and maximal at `d_max`. The effect is cluster cohesion: isolated cells drift back into the cluster instead of dispersing under stochastic noise.
+
+Like collisions, adhesion forces are applied on the tangent plane (Cartesian, section 5) and re-projected, so the magnitude is latitude-independent.
+
+---
+
+## 9. Dynamic Contour Deformation (Fourier Modes)
+
+To make the visualization biologically plausible, cell contours are perturbed by low-frequency Fourier modes:
+
+```
+R(theta, t) = R_base * ( 1 + epsilon * sum_{k=2..5} cos( k*theta + phi_k(t) ) )
+```
+
+| Symbol | Meaning |
+|---|---|
+| `R(theta, t)` | Instantaneous angular radius at contour parameter `theta` |
+| `R_base` | Nominal cell radius (user parameter) |
+| `epsilon` | Deformation amplitude (~0.05) |
+| `k` | Mode number (2 = elliptic, 3 = triangular, 4 = quadrupolar, 5 = pentagonal) |
+| `phi_k(t)` | Time-varying phase, `phi_k(t) = phi_k(0) + omega_k * t` |
+
+**Purpose.** Purely cosmetic: rigid-circle cells look computer-generated. Fourier perturbation mimics membrane fluctuations without affecting the centroid dynamics (the deformation is volume-preserving to leading order in `epsilon`).
+
+---
+
+## 10. Cluster Cohesion Metrics
+
+Real-time quantification of the DFC cluster state during simulation.
+
+### 10.1 Centroid
+
+```
+C = (1/N) * sum_i (az_i, el_i)
+```
+
+where `N` is the number of active cells. This is a mean in coordinate space, which is a good approximation while the cluster is small compared to the embryo (the usual case for DFCs).
+
+### 10.2 Spread (compactness)
+
+```
+sigma = sqrt( (1/N) * sum_i d_i^2 )
+```
+
+where `d_i` is the Haversine distance from cell `i` to the centroid `C`. Low `sigma` means a tight cluster; rising `sigma` signals fragmentation.
+
+### 10.3 Elongation
+
+```
+elongation = sqrt( lambda_max / lambda_min )
+```
+
+where `lambda_max`, `lambda_min` are the two eigenvalues of the 2D covariance matrix of cell positions (projected onto the tangent plane at `C`):
+
+```
+Cov = (1/N) * sum_i (p_i - C)(p_i - C)^T
+```
+
+| Elongation | Shape |
+|---|---|
+| ≈ 1 | Isotropic (circular) cluster |
+| ≈ 2 | Mildly stretched |
+| > 3 | Strong streaming migration |
+
+These metrics are exported in the CSV download and drive the right-panel status display.
+
+---
+
+## 11. Numerical Integration
+
+The simulator uses **forward Euler integration** with a fixed tick `dt = 1 step`:
+
+```
+az(t+1) = az(t) + v_az(t)
+el(t+1) = el(t) + v_el(t)
+```
+
+followed by wrap/clamp and collision/adhesion correction.
+
+**Accuracy.** Forward Euler has `O(dt)` local error. Because `dt` is small relative to `lambda` (the slowest timescale in the EVL coupling) and because all forces are bounded, the global error over a typical 500-step run stays well below the cell radius. Higher-order integrators (RK4, symplectic) were considered and rejected: the stochastic term dominates the residual, so additional deterministic accuracy is wasted.
+
+**Stability.** The combination of clamped elevation and bounded spring forces ensures no cell velocity can exceed `~2 * v_evl` per step under reasonable parameter choices.
+
+---
+
+## 12. Summary Table
+
+| Equation | Purpose | Section |
+|---|---|---|
+| `ds^2 = R^2 (d_el^2 + cos^2(el) d_az^2)` | Spherical metric | 2 |
+| `d_hav = 2 arcsin(sqrt(...))` | Great-circle distance | 3 |
+| `p_new = R * normalize(p + push * tangent)` | Cartesian push | 5 |
+| `F_EVL = k * d * exp(-d/lambda)` | EVL elastic coupling | 6 |
+| `v = v_EVL + alpha*bias + sigma*xi` | Persistent random walk | 7 |
+| `F_adh = s * (d - d_contact) / (d_max - d_contact)` | Differential adhesion | 8 |
+| `R(theta,t) = R_base (1 + eps sum cos(k*theta + phi_k(t)))` | Contour deformation | 9 |
+| `sigma = sqrt(mean(d^2))` | Cluster spread | 10 |
+| `elongation = sqrt(lambda_max / lambda_min)` | Cluster elongation | 10 |
+
+---
+
+## References
+
+The mathematical formulation here draws on:
+
+- Vincenty, T. (1975). Direct and inverse solutions of geodesics on the ellipsoid. *Survey Review*, 23(176). -- Haversine and geodesic formulas.
+- Steinberg, M. (1963). Reconstruction of tissues by dissociated cells. *Science*, 141(3579). -- Differential adhesion.
+- Ablooglu et al. (2021). Apical contacts stemming from incomplete delamination. *eLife*, 10:e61495. -- EVL elastic coupling motivation.
+- Rieu et al. (2000). Diffusion and deformations of single Hydra cells. *Biophysical Journal*, 79(4). -- Persistent random walk on surfaces.
+
+For the full bibliography see [references.md](references.md).

--- a/docs/svg/pipeline.svg
+++ b/docs/svg/pipeline.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" width="800" height="400">
+  <defs>
+    <linearGradient id="bgFlow" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1a1a2e"/>
+      <stop offset="100%" stop-color="#16213e"/>
+    </linearGradient>
+    <linearGradient id="stepBox" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1e3a5f"/>
+      <stop offset="100%" stop-color="#142a4a"/>
+    </linearGradient>
+    <linearGradient id="renderBox" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2a4a3c"/>
+      <stop offset="100%" stop-color="#1a3a2c"/>
+    </linearGradient>
+    <marker id="flowArrow" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#64b5f6"/>
+    </marker>
+    <marker id="loopArrow" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#ffab40"/>
+    </marker>
+    <filter id="boxShadow">
+      <feDropShadow dx="1" dy="2" stdDeviation="2" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="400" fill="url(#bgFlow)" rx="8"/>
+
+  <!-- Title -->
+  <text x="400" y="32" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="#e0e0e0">Simulation Pipeline (per time step)</text>
+
+  <!-- ===== ROW 1: Steps 1-4 ===== -->
+
+  <!-- Step 1: Init cells -->
+  <rect x="20" y="60" width="155" height="80" rx="8" fill="url(#stepBox)" stroke="#4a7ab5" stroke-width="1.5" filter="url(#boxShadow)"/>
+  <text x="97" y="82" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#90caf9">1. Initialize</text>
+  <text x="97" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#ccc">Place DFC cells on</text>
+  <text x="97" y="114" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#ccc">sphere in grid pattern</text>
+  <text x="97" y="132" text-anchor="middle" font-family="monospace" font-size="9" fill="#666">DFCLayer.initialize()</text>
+
+  <!-- Arrow 1->2 -->
+  <line x1="175" y1="100" x2="200" y2="100" stroke="#64b5f6" stroke-width="2" marker-end="url(#flowArrow)"/>
+
+  <!-- Step 2: Update positions -->
+  <rect x="205" y="60" width="155" height="80" rx="8" fill="url(#stepBox)" stroke="#4a7ab5" stroke-width="1.5" filter="url(#boxShadow)"/>
+  <text x="282" y="82" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#90caf9">2. Update Positions</text>
+  <text x="282" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#ccc">Apply EVL velocity</text>
+  <text x="282" y="114" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#ccc">+ Gaussian noise</text>
+  <text x="282" y="132" text-anchor="middle" font-family="monospace" font-size="9" fill="#666">cell.update(vel, noise)</text>
+
+  <!-- Arrow 2->3 -->
+  <line x1="360" y1="100" x2="385" y2="100" stroke="#64b5f6" stroke-width="2" marker-end="url(#flowArrow)"/>
+
+  <!-- Step 3: Detect collisions -->
+  <rect x="390" y="60" width="155" height="80" rx="8" fill="url(#stepBox)" stroke="#4a7ab5" stroke-width="1.5" filter="url(#boxShadow)"/>
+  <text x="467" y="82" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#90caf9">3. Detect Collisions</text>
+  <text x="467" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#ccc">Pairwise angular</text>
+  <text x="467" y="114" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#ccc">distance check O(n^2)</text>
+  <text x="467" y="132" text-anchor="middle" font-family="monospace" font-size="9" fill="#666">angular_distance(a,b)</text>
+
+  <!-- Arrow 3->4 -->
+  <line x1="545" y1="100" x2="570" y2="100" stroke="#64b5f6" stroke-width="2" marker-end="url(#flowArrow)"/>
+
+  <!-- Step 4: Resolve overlaps -->
+  <rect x="575" y="60" width="155" height="80" rx="8" fill="url(#stepBox)" stroke="#4a7ab5" stroke-width="1.5" filter="url(#boxShadow)"/>
+  <text x="652" y="82" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#90caf9">4. Resolve Overlaps</text>
+  <text x="652" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#ccc">Push cells apart</text>
+  <text x="652" y="114" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#ccc">symmetrically</text>
+  <text x="652" y="132" text-anchor="middle" font-family="monospace" font-size="9" fill="#666">solve_collisions(cells)</text>
+
+  <!-- Arrow 4 down to row 2 -->
+  <path d="M 730 120 L 755 120 L 755 210 L 730 210" fill="none" stroke="#64b5f6" stroke-width="2" marker-end="url(#flowArrow)"/>
+
+  <!-- ===== ROW 2: Steps 5-7 ===== -->
+
+  <!-- Step 5: Update cartesian -->
+  <rect x="575" y="175" width="155" height="80" rx="8" fill="url(#stepBox)" stroke="#4a7ab5" stroke-width="1.5" filter="url(#boxShadow)"/>
+  <text x="652" y="197" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#90caf9">5. Update Cartesian</text>
+  <text x="652" y="215" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#ccc">Convert AER centers</text>
+  <text x="652" y="229" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#ccc">and contours to XYZ</text>
+  <text x="652" y="247" text-anchor="middle" font-family="monospace" font-size="9" fill="#666">spherical_to_cartesian()</text>
+
+  <!-- Arrow 5->6 -->
+  <line x1="575" y1="215" x2="550" y2="215" stroke="#64b5f6" stroke-width="2" marker-end="url(#flowArrow)" transform="rotate(180,562,215)"/>
+
+  <!-- Step 6: Serialize state -->
+  <rect x="390" y="175" width="155" height="80" rx="8" fill="url(#stepBox)" stroke="#4a7ab5" stroke-width="1.5" filter="url(#boxShadow)"/>
+  <text x="467" y="197" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#90caf9">6. Serialize State</text>
+  <text x="467" y="215" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#ccc">Build JSON with all</text>
+  <text x="467" y="229" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#ccc">cell + env data</text>
+  <text x="467" y="247" text-anchor="middle" font-family="monospace" font-size="9" fill="#666">get_state() -&gt; JSON</text>
+
+  <!-- Arrow 6->7 -->
+  <line x1="390" y1="215" x2="365" y2="215" stroke="#64b5f6" stroke-width="2" marker-end="url(#flowArrow)" transform="rotate(180,377,215)"/>
+
+  <!-- Step 7: Render in Three.js -->
+  <rect x="205" y="175" width="155" height="80" rx="8" fill="url(#renderBox)" stroke="#4a8c5a" stroke-width="1.5" filter="url(#boxShadow)"/>
+  <text x="282" y="197" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#a5d6a7">7. Render (Three.js)</text>
+  <text x="282" y="215" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#ccc">Update 3D scene:</text>
+  <text x="282" y="229" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#ccc">sphere + cell contours</text>
+  <text x="282" y="247" text-anchor="middle" font-family="monospace" font-size="9" fill="#666">renderer3d.updateCells()</text>
+
+  <!-- ===== LOOP ARROW (back from Render to Step 2) ===== -->
+  <path d="M 205 215 L 50 215 L 50 55 L 282 55 L 282 60" fill="none" stroke="#ffab40" stroke-width="2" stroke-dasharray="6,4" marker-end="url(#loopArrow)"/>
+  <text x="50" y="140" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#ffab40" transform="rotate(-90,50,140)">Repeat each tick</text>
+
+  <!-- ===== WebSocket label on the serialize->render connection ===== -->
+  <rect x="338" y="195" width="55" height="18" rx="3" fill="#1a1a2e"/>
+  <text x="365" y="208" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" font-weight="bold" fill="#64b5f6">WebSocket</text>
+
+  <!-- ===== Bottom: Key parameters ===== -->
+  <rect x="60" y="290" width="680" height="95" rx="8" fill="#0d1520" fill-opacity="0.8" stroke="#3a5a7a" stroke-width="1"/>
+  <text x="400" y="312" text-anchor="middle" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#ccc">Key Parameters Affecting the Pipeline</text>
+
+  <text x="100" y="335" font-family="monospace" font-size="10" fill="#90caf9">evl_speed</text>
+  <text x="100" y="350" font-family="Arial, sans-serif" font-size="9" fill="#999">EVL margin velocity</text>
+
+  <text x="250" y="335" font-family="monospace" font-size="10" fill="#90caf9">noise_std</text>
+  <text x="250" y="350" font-family="Arial, sans-serif" font-size="9" fill="#999">Gaussian perturbation</text>
+
+  <text x="400" y="335" font-family="monospace" font-size="10" fill="#90caf9">radial_size</text>
+  <text x="400" y="350" font-family="Arial, sans-serif" font-size="9" fill="#999">Cell angular radius</text>
+
+  <text x="545" y="335" font-family="monospace" font-size="10" fill="#90caf9">num_dfcs</text>
+  <text x="545" y="350" font-family="Arial, sans-serif" font-size="9" fill="#999">Cell population count</text>
+
+  <text x="680" y="335" font-family="monospace" font-size="10" fill="#90caf9">speed_ms</text>
+  <text x="680" y="350" font-family="Arial, sans-serif" font-size="9" fill="#999">Tick interval (ms)</text>
+
+  <text x="400" y="375" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#666">Steps 2-7 repeat at intervals of speed_ms milliseconds when the simulation is running</text>
+</svg>

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -121,6 +121,18 @@ The viewport supports standard Three.js OrbitControls:
 
 You can also use touch gestures on mobile devices (one finger to rotate, two fingers to pan/pinch to zoom).
 
+### Keyboard Shortcuts
+
+| Key | Action |
+|---|---|
+| **Space** | Toggle Play / Pause |
+| **S** | Single step (advance one frame) |
+| **I** | Init / reset simulation with current parameters |
+| **?** | Open the help modal |
+| **Esc** | Close the help modal |
+
+A small overlay in the bottom-left of the viewport lists these shortcuts at runtime. Click the `-` button on the overlay to collapse it (or `+` to restore). Shortcuts are ignored while the focus is inside an input field, so parameter editing is not affected.
+
 ## Running the Tests
 
 The project includes 23 tests organized into three test files. Run them from the project root:


### PR DESCRIPTION
Closes #24

## Summary

Raises the repo to the project-quality-standards bar on three items identified in this cycle's audit:

- **New deep theory reference** — `docs/spherical_mechanics_theory.md`. 12 sections covering AER coordinates, the spherical metric and why flat geometry fails, Haversine distance, Cartesian tangent-plane collision resolution, EVL elastic spring coupling, persistent random walk, differential adhesion, Fourier contour deformation, cluster metrics, and forward Euler integration. Each equation has a variable table and physical/numerical interpretation.
- **Standards-named pipeline SVG** — `docs/svg/pipeline.svg` (mirrors existing `simulation_flow.svg`) plus a new Pipeline section in the README between Architecture and Features.
- **Viewport keyboard shortcuts** — Space (play/pause), S (step), I (init), ? (help), Esc (close). Collapsible overlay in the bottom-left lists keys and mouse gestures. Shortcuts are suppressed while typing in inputs.

## Touched files

- README.md (documentation links, project-structure tree, Pipeline section)
- app/static/index.html (hints overlay + keyboard handler)
- app/static/css/style.css (hints overlay styling)
- docs/spherical_mechanics_theory.md (new, ~250 lines)
- docs/svg/pipeline.svg (new)
- docs/user_guide.md (Keyboard Shortcuts subsection)

## Test plan

- [x] `python tests/test_cell.py` — 12 pass
- [x] `python tests/test_collision.py` — 9 pass
- [x] `python tests/test_simulation.py` — 10 pass
- [ ] Manual: load http://localhost:8002, confirm hints overlay renders, Space toggles play/pause, S steps one frame, I reinitialises, ? opens help, Esc closes help, clicking `-` collapses the overlay.
- [ ] Manual: confirm README renders Pipeline section with the SVG.