### PR TITLE
Feat: Add /api/health and /api/version endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -26,6 +26,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse, StreamingResponse
 from pydantic import BaseModel
 
+from . import __version__
 from .simulation.layer_dfc import DFCLayer
 from .simulation.environment import SphericalEnvironment
 
@@ -33,10 +34,12 @@ from .simulation.environment import SphericalEnvironment
 # App setup
 # ---------------------------------------------------------------------------
 
+APP_TITLE = "SCIAN EVL SpherSIM"
+
 app = FastAPI(
-    title="SCIAN EVL SpherSIM",
+    title=APP_TITLE,
     description="3D spherical simulation of embryonic cell migration",
-    version="2.0.0",
+    version=__version__,
 )
 
 static_dir = Path(__file__).parent / "static"
@@ -78,6 +81,27 @@ class SimConfig(BaseModel):
 async def root():
     """Serve the single-page application."""
     return FileResponse(str(static_dir / "index.html"))
+
+
+@app.get("/api/health")
+async def health():
+    """Lightweight liveness probe.
+
+    Returns a stable ``{"status": "ok"}`` payload with HTTP 200. Intended
+    for uptime monitors, cPanel health-checks, and local smoke tests.
+    """
+    return {"status": "ok"}
+
+
+@app.get("/api/version")
+async def version():
+    """Expose the deployed application version.
+
+    Sources the version string from :data:`app.__version__` (single source
+    of truth) and the service name from the FastAPI ``title``. Useful for
+    verifying which build is running in a given environment.
+    """
+    return {"version": __version__, "name": APP_TITLE}
 
 
 @app.post("/api/simulation/init")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,37 @@
+"""
+Route-level tests for service-introspection endpoints.
+
+Covers ``GET /api/health`` and ``GET /api/version``. These endpoints are
+used by uptime monitors and deploy-verification smoke tests, so a broken
+payload here breaks operational tooling — worth a guard.
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from fastapi.testclient import TestClient
+
+from app import __version__
+from app.main import app, APP_TITLE
+
+
+client = TestClient(app)
+
+
+def test_health_endpoint_returns_ok():
+    """GET /api/health returns HTTP 200 with the stable status payload."""
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_version_endpoint_matches_module_constant():
+    """GET /api/version returns HTTP 200 with version == app.__version__."""
+    response = client.get("/api/version")
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["version"] == __version__
+    assert payload["name"] == APP_TITLE


### PR DESCRIPTION
## Summary

Adds two lightweight service-introspection endpoints to the FastAPI backend:

- `GET /api/health` → `{"status": "ok"}`, HTTP 200. Uptime/probe target.
- `GET /api/version` → `{"version": "2.0.0", "name": "SCIAN EVL SpherSIM"}`, HTTP 200. Sourced from `app.__version__` so the version string has a single source of truth.

Also refactors `FastAPI(version=...)` in `app/main.py` to read the same module constant instead of a hard-coded literal — release bumps now happen in exactly one place (`app/__init__.py`).

## Test plan

- `pytest tests/test_api.py -v` → 2/2 passed (new tests).
- `pytest tests/ -v` → 33/33 passed (full suite, no regressions).
- Manual curl: not performed on this host (no uvicorn runtime during PR prep); `TestClient(app)` exercises the full ASGI stack end-to-end and is equivalent for the payload assertions.

## Notes

- Endpoints live at the top level of `app/main.py` rather than in `app/api/routes.py` because probe endpoints are service-level concerns, not part of the `/api/simulation/*` domain. `routes.py` stays reserved for future simulation-adjacent expansion.
- `importlib.metadata` was considered and skipped — the app is not `pip`-packaged; `__init__.py` constant is authoritative.

Closes #31